### PR TITLE
Use a dynamic module to include the writing methods that are generated from using belongs_to

### DIFF
--- a/lib/polymorphic_integer_type/version.rb
+++ b/lib/polymorphic_integer_type/version.rb
@@ -1,3 +1,3 @@
 module PolymorphicIntegerType
-  VERSION = "2.2.2"
+  VERSION = "2.2.3"
 end

--- a/spec/support/link.rb
+++ b/spec/support/link.rb
@@ -3,4 +3,12 @@ class Link < ActiveRecord::Base
 
   belongs_to :source, polymorphic: true, integer_type: true
   belongs_to :target, polymorphic: true, integer_type: true
+
+  def source=(val)
+    super(val)
+  end
+
+  def source_type=(val)
+    super(val)
+  end
 end


### PR DESCRIPTION
Prior to this, if we have something like
```
class Link < ActiveRecord::Base
  include PolymorphicIntegerType::Extensions

  belongs_to :source, polymorphic: true, integer_type: true
  belongs_to :target, polymorphic: true, integer_type: true

  def source=(val)
    super(val)
  end

  def source_type=(val)
    super(val)
  end
end
```

the `source=` will override the method defined by the `belongs_to` and what will end up happening is that the `source_type` will not end up being created properly. 

By created an anonymous module, we can prepend it to the class and then the `super` behaviour will work as expected. 