### PR TITLE
Spec config fixes for rails 5

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     database_config = YAML.load(File.open("#{File.dirname(__FILE__)}/support/database.yml"))
     ActiveRecord::Base.establish_connection(database_config)
-    if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("5")
+    if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("5.2.0")
       ActiveRecord::MigrationContext.new("#{File.dirname(__FILE__)}/support/migrations").migrate
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'support/dog'
 require 'support/person'
 require 'support/food'
 require 'support/drink'
+require 'byebug'
 
 RSpec.configure do |config|
   config.before(:suite) do


### PR DESCRIPTION
Two small improvements to make running specs and debugging easier.

* Adds `byebug` to spec_helper so we can drop it in when we need
* Changes the conditional for running migrations under Rails 5. `MigrationContext` was only [added in Rails 5.2](https://github.com/rails/rails/commit/a2827ec9811b5012e8e366011fd44c8eb53fc714).