### PR TITLE
Add a Rake task to run specs for multiple versions of Rails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 require "bundler/gem_tasks"
 require "yaml"
 require "active_record"
-require "byebug"
 
 namespace :test do
   task :all do

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,18 @@
 require "bundler/gem_tasks"
 require "yaml"
 require "active_record"
+require "byebug"
+
+namespace :test do
+  task :all do
+    Dir.glob("./gemfiles/Gemfile*").each do |gemfile|
+      next if gemfile.end_with?(".lock")
+      puts "Running specs for #{Pathname.new(gemfile).basename}"
+      system("BUNDLE_GEMFILE=#{gemfile} bundle install > /dev/null && BUNDLE_GEMFILE=#{gemfile} bundle exec rspec")
+      puts ""
+    end
+  end
+end
 
 namespace :db do
   database_config = YAML.load(File.open("./spec/support/database.yml"))

--- a/gemfiles/Gemfile.rails-4.2-stable
+++ b/gemfiles/Gemfile.rails-4.2-stable
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "activerecord", github: "rails/rails", branch: "4-2-stable"
+gem "sqlite3", "~> 1.3.6"

--- a/gemfiles/Gemfile.rails-4.2-stable.lock
+++ b/gemfiles/Gemfile.rails-4.2-stable.lock
@@ -1,0 +1,68 @@
+GIT
+  remote: git://github.com/rails/rails.git
+  revision: e9d6b85f3e834ceea2aeabe4cbaa96a7c73eb896
+  branch: 4-2-stable
+  specs:
+    activemodel (4.2.11.1)
+      activesupport (= 4.2.11.1)
+      builder (~> 3.1)
+    activerecord (4.2.11.1)
+      activemodel (= 4.2.11.1)
+      activesupport (= 4.2.11.1)
+      arel (~> 6.0)
+    activesupport (4.2.11.1)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+
+PATH
+  remote: ..
+  specs:
+    polymorphic_integer_type (2.2.4)
+      activerecord
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    arel (6.0.4)
+    builder (3.2.4)
+    byebug (11.0.1)
+    concurrent-ruby (1.1.5)
+    diff-lcs (1.3)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    minitest (5.13.0)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
+    sqlite3 (1.3.13)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord!
+  bundler
+  byebug
+  polymorphic_integer_type!
+  rake
+  rspec
+  sqlite3 (~> 1.3.6)
+
+BUNDLED WITH
+   1.16.1

--- a/gemfiles/Gemfile.rails-5.0-stable
+++ b/gemfiles/Gemfile.rails-5.0-stable
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "activerecord", github: "rails/rails", branch: "5-0-stable"
+gem "sqlite3", "~> 1.3.6"

--- a/gemfiles/Gemfile.rails-5.0-stable.lock
+++ b/gemfiles/Gemfile.rails-5.0-stable.lock
@@ -1,0 +1,66 @@
+GIT
+  remote: git://github.com/rails/rails.git
+  revision: ac6aa32f7cf66264ba87eabed7c042bb60bcf3a2
+  branch: 5-0-stable
+  specs:
+    activemodel (5.0.7.2)
+      activesupport (= 5.0.7.2)
+    activerecord (5.0.7.2)
+      activemodel (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
+      arel (~> 7.0)
+    activesupport (5.0.7.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+
+PATH
+  remote: ..
+  specs:
+    polymorphic_integer_type (2.2.4)
+      activerecord
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    arel (7.1.4)
+    byebug (11.0.1)
+    concurrent-ruby (1.1.5)
+    diff-lcs (1.3)
+    i18n (1.7.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.13.0)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
+    sqlite3 (1.3.13)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord!
+  bundler
+  byebug
+  polymorphic_integer_type!
+  rake
+  rspec
+  sqlite3 (~> 1.3.6)
+
+BUNDLED WITH
+   1.16.1

--- a/gemfiles/Gemfile.rails-5.1-stable
+++ b/gemfiles/Gemfile.rails-5.1-stable
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "activerecord", github: "rails/rails", branch: "5-1-stable"

--- a/gemfiles/Gemfile.rails-5.1-stable.lock
+++ b/gemfiles/Gemfile.rails-5.1-stable.lock
@@ -1,0 +1,66 @@
+GIT
+  remote: git://github.com/rails/rails.git
+  revision: 663206d20aec374a28a24bb43bc7b1233042ed9b
+  branch: 5-1-stable
+  specs:
+    activemodel (5.1.7)
+      activesupport (= 5.1.7)
+    activerecord (5.1.7)
+      activemodel (= 5.1.7)
+      activesupport (= 5.1.7)
+      arel (~> 8.0)
+    activesupport (5.1.7)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+
+PATH
+  remote: ..
+  specs:
+    polymorphic_integer_type (2.2.4)
+      activerecord
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    arel (8.0.0)
+    byebug (11.0.1)
+    concurrent-ruby (1.1.5)
+    diff-lcs (1.3)
+    i18n (1.7.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.13.0)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
+    sqlite3 (1.4.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord!
+  bundler
+  byebug
+  polymorphic_integer_type!
+  rake
+  rspec
+  sqlite3
+
+BUNDLED WITH
+   1.16.1

--- a/gemfiles/Gemfile.rails-5.2-stable
+++ b/gemfiles/Gemfile.rails-5.2-stable
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "activerecord", github: "rails/rails", branch: "5-2-stable"

--- a/gemfiles/Gemfile.rails-5.2-stable.lock
+++ b/gemfiles/Gemfile.rails-5.2-stable.lock
@@ -1,0 +1,66 @@
+GIT
+  remote: git://github.com/rails/rails.git
+  revision: 892eab777c418135ce0646e91bc9ebb08a29ab9b
+  branch: 5-2-stable
+  specs:
+    activemodel (5.2.4.1)
+      activesupport (= 5.2.4.1)
+    activerecord (5.2.4.1)
+      activemodel (= 5.2.4.1)
+      activesupport (= 5.2.4.1)
+      arel (>= 9.0)
+    activesupport (5.2.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+
+PATH
+  remote: ..
+  specs:
+    polymorphic_integer_type (2.2.4)
+      activerecord
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    arel (9.0.0)
+    byebug (11.0.1)
+    concurrent-ruby (1.1.5)
+    diff-lcs (1.3)
+    i18n (1.7.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.13.0)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
+    sqlite3 (1.4.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord!
+  bundler
+  byebug
+  polymorphic_integer_type!
+  rake
+  rspec
+  sqlite3
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
Since we support versions of Rails from 4 onwards, and we now have many version-specific patches, it would be nice to have an easy way to run specs on all supported versions to verify new changes.

This PR adds a rake task, `test:all`, which iterates through a collection of Gemfiles and run the specs.

The organization of the Gemfiles is inspired by [devise](https://github.com/plataformatec/devise), which takes a similar approach to managing different Rails versions.

🎬 Here it is in action:

```
$ rake test:all 2> /dev/null
Running specs for Gemfile.rails-5.0-stable
............................

Finished in 0.19595 seconds (files took 0.52644 seconds to load)
28 examples, 0 failures


Running specs for Gemfile.rails-5.2-stable
............................

Finished in 0.2064 seconds (files took 0.55434 seconds to load)
28 examples, 0 failures


Running specs for Gemfile.rails-4.2-stable
............................

Finished in 0.19892 seconds (files took 0.42005 seconds to load)
28 examples, 0 failures


Running specs for Gemfile.rails-5.1-stable
............................

Finished in 0.2044 seconds (files took 0.52197 seconds to load)
28 examples, 0 failures
```