### PR TITLE
Change how constant name is found

### DIFF
--- a/lib/polymorphic_integer_type/extensions.rb
+++ b/lib/polymorphic_integer_type/extensions.rb
@@ -95,7 +95,7 @@ module PolymorphicIntegerType
       def retrieve_polymorphic_type_mapping(polymorphic_type:, class_name:)
         return if polymorphic_type.nil?
 
-        belongs_to_class = class_name.safe_constantize
+        belongs_to_class = compute_type(class_name)
         method_name = "#{polymorphic_type}_type_mapping"
 
         if belongs_to_class && belongs_to_class.respond_to?(method_name)

--- a/lib/polymorphic_integer_type/version.rb
+++ b/lib/polymorphic_integer_type/version.rb
@@ -1,3 +1,3 @@
 module PolymorphicIntegerType
-  VERSION = "2.2.4"
+  VERSION = "2.2.5"
 end

--- a/spec/polymorphic_integer_type_spec.rb
+++ b/spec/polymorphic_integer_type_spec.rb
@@ -261,7 +261,7 @@ describe PolymorphicIntegerType do
 
       self.table_name = "drinks"
 
-      has_many :inline_links2, as: :target
+      has_many :inline_link2s, as: :target
     end
 
     let!(:animal) { InlineAnimal2.create!(name: "Lucy") }


### PR DESCRIPTION
Use `compute_type` instead of `safe_constantize` to get the class. This will try to resolve the module to the current module so it can resolve the constant without explicitly adding the module name. 

For reference: 
`safe_constantize`: https://apidock.com/rails/ActiveSupport/Inflector/safe_constantize
`compute_type`: https://apidock.com/rails/ActiveRecord/Inheritance/ClassMethods/compute_type

This also fixes a typo in a spec that failed with this change.