### PR TITLE
Add support for the rails 5.2 polymorphic name method

### DIFF
--- a/lib/polymorphic_integer_type/extensions.rb
+++ b/lib/polymorphic_integer_type/extensions.rb
@@ -46,6 +46,7 @@ module PolymorphicIntegerType
             define_method "#{name}=" do |record|
               super(record)
               send("#{foreign_type}=", record.class)
+              association(name).loaded!
             end
           end
 

--- a/lib/polymorphic_integer_type/extensions.rb
+++ b/lib/polymorphic_integer_type/extensions.rb
@@ -34,6 +34,7 @@ module PolymorphicIntegerType
               mapping = self.class.send("#{foreign_type}_mapping")
               enum = mapping.key(klass.to_s)
               if klass.kind_of?(Class) && klass <= ActiveRecord::Base
+                enum ||= mapping.key(klass.polymorphic_name) if klass.respond_to?(:polymorphic_name)
                 enum ||= mapping.key(klass.sti_name)
                 enum ||= mapping.key(klass.base_class.to_s)
                 enum ||= mapping.key(klass.base_class.sti_name)
@@ -69,14 +70,15 @@ module PolymorphicIntegerType
         if options[:as] && (polymorphic_type_mapping || integer_type)
           poly_type = options.delete(:as)
           polymorphic_type_mapping ||= PolymorphicIntegerType::Mapping[poly_type]
-          if polymorphic_type_mapping == nil
+          if polymorphic_type_mapping.nil?
             raise "Polymorphic type mapping missing for #{poly_type.inspect}"
           end
 
-          klass_mapping = (polymorphic_type_mapping || {}).key(sti_name)
+          klass_mapping = polymorphic_type_mapping.key(polymorphic_name) if respond_to?(:polymorphic_name)
+          klass_mapping ||= polymorphic_type_mapping.key(sti_name)
 
-          if klass_mapping == nil
-            raise "Class not found for #{sti_name.inspect} in polymorphic type mapping: #{polymorphic_type_mapping}"
+          if klass_mapping.nil?
+            raise "Class not found for #{inspect} in polymorphic type mapping: #{polymorphic_type_mapping}"
           end
 
           options[:foreign_key] ||= "#{poly_type}_id"

--- a/lib/polymorphic_integer_type/version.rb
+++ b/lib/polymorphic_integer_type/version.rb
@@ -1,3 +1,3 @@
 module PolymorphicIntegerType
-  VERSION = "2.2.5"
+  VERSION = "2.3.0"
 end

--- a/spec/polymorphic_integer_type_spec.rb
+++ b/spec/polymorphic_integer_type_spec.rb
@@ -25,6 +25,25 @@ describe PolymorphicIntegerType do
   end
 
   context "when the source is a class that modifies the sti_name or polymorphic_name" do
+    context "and we leverage the polymorphic_name" do
+      before do
+        allow(PolymorphicIntegerType).to receive(:use_polymorphic_name).and_return(true)
+      end
+
+      it "properly sets the source_type to the modified class name" do
+        link = Link.new(source: Namespaced::Animal.new)
+        expect(link.source_type).to eql "Animal"
+      end
+
+      it "can read dirty attributes from an associated object" do
+        animal = Namespaced::Animal.create!(name: "Oldie")
+        animal.name = "Newton"
+        link = Link.create!(source: animal)
+
+        expect(link.source.name).to eq("Newton")
+      end
+    end
+
     it "properly sets the source_type to the modified class name" do
       link = Link.new(source: Namespaced::Animal.new)
       expect(link.source_type).to eql "Animal"


### PR DESCRIPTION
### What problem does this solve

Prior to Rails 5.2, there wasn't a great consensus on what to use for the polymorphic_name of a class. In some instance it was the class name, in other instances, it seemed like it was the name that was used for single table inheritance. 

As of Rails 5.2, there is now a canonical way which is to call `polymorphic_name` on the class. Now that there is a canonical way, we should remove the redundant lookups

### How does this solve it

We don't want to completely break support, so this will check if a class responds to `polymorphic_name` and if so, it'll use that. It'll keep all of the other fallbacks in place though. 